### PR TITLE
Test 1: screen must be unchanged during isPending true period

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,335 +72,333 @@ yarn run jest
 <summary>Raw Output</summary>
 
 ```
- react-redux
-   with useTransition
-     ✕ test 1: updated properly with transition (1620 ms)
-     ✕ test 2: no tearing with transition (844 ms)
-     ✓ test 3: ability to interrupt render (1 ms)
-     ✕ test 4: proper branching with transition (7181 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (2205 ms)
-     ✕ test 6: no tearing with auto increment (2 ms)
- redux-use-mutable-source
-   with useTransition
-     ✓ test 1: updated properly with transition (2739 ms)
-     ✓ test 2: no tearing with transition (129 ms)
-     ✓ test 3: ability to interrupt render
-     ✕ test 4: proper branching with transition (7520 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (2200 ms)
-     ✕ test 6: no tearing with auto increment (2 ms)
- reactive-react-redux
-   with useTransition
-     ✓ test 1: updated properly with transition (2708 ms)
-     ✓ test 2: no tearing with transition (131 ms)
-     ✓ test 3: ability to interrupt render
-     ✕ test 4: proper branching with transition (7497 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (2204 ms)
-     ✕ test 6: no tearing with auto increment (2 ms)
- react-tracked
-   with useTransition
-     ✓ test 1: updated properly with transition (3573 ms)
-     ✓ test 2: no tearing with transition (94 ms)
-     ✓ test 3: ability to interrupt render
-     ✓ test 4: proper branching with transition (5454 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (6110 ms)
-     ✓ test 6: no tearing with auto increment (1 ms)
- constate
-   with useTransition
-     ✓ test 1: updated properly with transition (2812 ms)
-     ✓ test 2: no tearing with transition (39 ms)
-     ✓ test 3: ability to interrupt render (1 ms)
-     ✓ test 4: proper branching with transition (3469 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (3987 ms)
-     ✓ test 6: no tearing with auto increment (1 ms)
- zustand
-   with useTransition
-     ✕ test 1: updated properly with transition (1584 ms)
-     ✕ test 2: no tearing with transition (861 ms)
-     ✓ test 3: ability to interrupt render
-     ✕ test 4: proper branching with transition (7168 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (2196 ms)
-     ✕ test 6: no tearing with auto increment (1 ms)
- react-hooks-global-state
-   with useTransition
-     ✓ test 1: updated properly with transition (3330 ms)
-     ✓ test 2: no tearing with transition (43 ms)
-     ✓ test 3: ability to interrupt render
-     ✕ test 4: proper branching with transition (7187 ms)
-   with intensive auto increment
-     ✕ test 5: updated properly with auto increment (13182 ms)
-     ✕ test 6: no tearing with auto increment (1 ms)
- use-context-selector
-   with useTransition
-     ✓ test 1: updated properly with transition (3584 ms)
-     ✓ test 2: no tearing with transition (50 ms)
-     ✓ test 3: ability to interrupt render (1 ms)
-     ✓ test 4: proper branching with transition (5350 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (6137 ms)
-     ✓ test 6: no tearing with auto increment (2 ms)
- use-subscription
-   with useTransition
-     ✓ test 1: updated properly with transition (3465 ms)
-     ✓ test 2: no tearing with transition (134 ms)
-     ✓ test 3: ability to interrupt render
-     ✕ test 4: proper branching with transition (7514 ms)
-   with intensive auto increment
-     ✕ test 5: updated properly with auto increment (13175 ms)
-     ✕ test 6: no tearing with auto increment (2 ms)
- react-state
-   with useTransition
-     ✓ test 1: updated properly with transition (2759 ms)
-     ✓ test 2: no tearing with transition (36 ms)
-     ✓ test 3: ability to interrupt render
-     ✓ test 4: proper branching with transition (3442 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (4007 ms)
-     ✓ test 6: no tearing with auto increment (2 ms)
- simplux
-   with useTransition
-     ✓ test 1: updated properly with transition (2809 ms)
-     ✓ test 2: no tearing with transition (39 ms)
-     ✓ test 3: ability to interrupt render (1 ms)
-     ✕ test 4: proper branching with transition (7347 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (4067 ms)
-     ✓ test 6: no tearing with auto increment (1 ms)
- apollo-client
-   with useTransition
-     ✕ test 1: updated properly with transition (4577 ms)
-     ✕ test 2: no tearing with transition (39 ms)
-     ✕ test 3: ability to interrupt render (1 ms)
-     ✕ test 4: proper branching with transition (3550 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (2242 ms)
-     ✕ test 6: no tearing with auto increment (1 ms)
- recoil
-   with useTransition
-     ✕ test 1: updated properly with transition (5774 ms)
-     ✓ test 2: no tearing with transition (40 ms)
-     ✕ test 3: ability to interrupt render
-     ✕ test 4: proper branching with transition (4473 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (3003 ms)
-     ✓ test 6: no tearing with auto increment (1 ms)
- jotai
-   with useTransition
-     ✓ test 1: updated properly with transition (3489 ms)
-     ✓ test 2: no tearing with transition (132 ms)
-     ✓ test 3: ability to interrupt render
-     ✕ test 4: proper branching with transition (7523 ms)
-   with intensive auto increment
-     ✕ test 5: updated properly with auto increment (13180 ms)
-     ✕ test 6: no tearing with auto increment (1 ms)
- effector
-   with useTransition
-     ✕ test 1: updated properly with transition (1600 ms)
-     ✕ test 2: no tearing with transition (873 ms)
-     ✓ test 3: ability to interrupt render
-     ✕ test 4: proper branching with transition (7135 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (2198 ms)
-     ✕ test 6: no tearing with auto increment (1 ms)
- react-rxjs
-   with useTransition
-     ✕ test 1: updated properly with transition (5749 ms)
-     ✓ test 2: no tearing with transition (37 ms)
-     ✕ test 3: ability to interrupt render (1 ms)
-     ✕ test 4: proper branching with transition (4488 ms)
-   with intensive auto increment
-     ✓ test 5: updated properly with auto increment (2999 ms)
-     ✓ test 6: no tearing with auto increment (1 ms)
- valtio
-   with useTransition
-     ✓ test 1: updated properly with transition (3374 ms)
-     ✓ test 2: no tearing with transition (39 ms)
-     ✓ test 3: ability to interrupt render
-     ✕ test 4: proper branching with transition (7179 ms)
-   with intensive auto increment
-     ✕ test 5: updated properly with auto increment (13172 ms)
-     ✕ test 6: no tearing with auto increment (1 ms)
- proxily
-   with useTransition
-     ✓ test 1: updated properly with transition (2809 ms)
-     ✓ test 2: no tearing with transition (42 ms)
-     ✓ test 3: ability to interrupt render (1 ms)
-     ✕ test 4: proper branching with transition (7372 ms)
-   with intensive auto increment
-     ✕ test 5: updated properly with auto increment (12180 ms)
-     ✓ test 6: no tearing with auto increment (2 ms)
-
+  react-redux
+    with useTransition
+      ✓ test 1: updated properly with transition (2711 ms)
+      ✕ test 2: no tearing with transition (56 ms)
+      ✓ test 3: ability to interrupt render
+      ✕ test 4: proper branching with transition (7201 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (2230 ms)
+      ✕ test 6: no tearing with auto increment (1 ms)
+  redux-use-mutable-source
+    with useTransition
+      ✓ test 1: updated properly with transition (2745 ms)
+      ✓ test 2: no tearing with transition (122 ms)
+      ✓ test 3: ability to interrupt render
+      ✕ test 4: proper branching with transition (7512 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (2229 ms)
+      ✕ test 6: no tearing with auto increment (1 ms)
+  reactive-react-redux
+    with useTransition
+      ✓ test 1: updated properly with transition (2738 ms)
+      ✓ test 2: no tearing with transition (121 ms)
+      ✓ test 3: ability to interrupt render
+      ✕ test 4: proper branching with transition (7536 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (2205 ms)
+      ✕ test 6: no tearing with auto increment (1 ms)
+  react-tracked
+    with useTransition
+      ✓ test 1: updated properly with transition (3632 ms)
+      ✓ test 2: no tearing with transition (29 ms)
+      ✓ test 3: ability to interrupt render
+      ✓ test 4: proper branching with transition (5411 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (6182 ms)
+      ✓ test 6: no tearing with auto increment (1 ms)
+  constate
+    with useTransition
+      ✓ test 1: updated properly with transition (2863 ms)
+      ✓ test 2: no tearing with transition (46 ms)
+      ✓ test 3: ability to interrupt render
+      ✓ test 4: proper branching with transition (3396 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (4006 ms)
+      ✓ test 6: no tearing with auto increment (1 ms)
+  zustand
+    with useTransition
+      ✓ test 1: updated properly with transition (2653 ms)
+      ✕ test 2: no tearing with transition (46 ms)
+      ✓ test 3: ability to interrupt render
+      ✕ test 4: proper branching with transition (7211 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (2208 ms)
+      ✕ test 6: no tearing with auto increment (1 ms)
+  react-hooks-global-state
+    with useTransition
+      ✓ test 1: updated properly with transition (3496 ms)
+      ✓ test 2: no tearing with transition (25 ms)
+      ✓ test 3: ability to interrupt render
+      ✕ test 4: proper branching with transition (7211 ms)
+    with intensive auto increment
+      ✕ test 5: updated properly with auto increment (13189 ms)
+      ✕ test 6: no tearing with auto increment (4 ms)
+  use-context-selector
+    with useTransition
+      ✓ test 1: updated properly with transition (3626 ms)
+      ✓ test 2: no tearing with transition (31 ms)
+      ✓ test 3: ability to interrupt render
+      ✓ test 4: proper branching with transition (5422 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (6149 ms)
+      ✓ test 6: no tearing with auto increment (1 ms)
+  use-subscription
+    with useTransition
+      ✓ test 1: updated properly with transition (3531 ms)
+      ✓ test 2: no tearing with transition (122 ms)
+      ✓ test 3: ability to interrupt render
+      ✕ test 4: proper branching with transition (7531 ms)
+    with intensive auto increment
+      ✕ test 5: updated properly with auto increment (13207 ms)
+      ✕ test 6: no tearing with auto increment (6 ms)
+  react-state
+    with useTransition
+      ✓ test 1: updated properly with transition (2828 ms)
+      ✓ test 2: no tearing with transition (43 ms)
+      ✓ test 3: ability to interrupt render
+      ✓ test 4: proper branching with transition (3408 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (4014 ms)
+      ✓ test 6: no tearing with auto increment (1 ms)
+  simplux
+    with useTransition
+      ✓ test 1: updated properly with transition (2813 ms)
+      ✓ test 2: no tearing with transition (46 ms)
+      ✓ test 3: ability to interrupt render (1 ms)
+      ✕ test 4: proper branching with transition (7364 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (4097 ms)
+      ✓ test 6: no tearing with auto increment (1 ms)
+  apollo-client
+    with useTransition
+      ✕ test 1: updated properly with transition (4837 ms)
+      ✕ test 2: no tearing with transition (51 ms)
+      ✕ test 3: ability to interrupt render (1 ms)
+      ✕ test 4: proper branching with transition (3675 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (2279 ms)
+      ✕ test 6: no tearing with auto increment (1 ms)
+  recoil
+    with useTransition
+      ✕ test 1: updated properly with transition (5603 ms)
+      ✓ test 2: no tearing with transition (53 ms)
+      ✕ test 3: ability to interrupt render (1 ms)
+      ✕ test 4: proper branching with transition (4367 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (3062 ms)
+      ✓ test 6: no tearing with auto increment (1 ms)
+  jotai
+    with useTransition
+      ✓ test 1: updated properly with transition (3562 ms)
+      ✓ test 2: no tearing with transition (122 ms)
+      ✓ test 3: ability to interrupt render
+      ✕ test 4: proper branching with transition (7543 ms)
+    with intensive auto increment
+      ✕ test 5: updated properly with auto increment (13214 ms)
+      ✕ test 6: no tearing with auto increment (4 ms)
+  effector
+    with useTransition
+      ✓ test 1: updated properly with transition (2677 ms)
+      ✕ test 2: no tearing with transition (48 ms)
+      ✓ test 3: ability to interrupt render
+      ✕ test 4: proper branching with transition (7184 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (2218 ms)
+      ✕ test 6: no tearing with auto increment (1 ms)
+  react-rxjs
+    with useTransition
+      ✕ test 1: updated properly with transition (5886 ms)
+      ✓ test 2: no tearing with transition (58 ms)
+      ✕ test 3: ability to interrupt render
+      ✕ test 4: proper branching with transition (4521 ms)
+    with intensive auto increment
+      ✓ test 5: updated properly with auto increment (3014 ms)
+      ✓ test 6: no tearing with auto increment (2 ms)
+  valtio
+    with useTransition
+      ✓ test 1: updated properly with transition (3453 ms)
+      ✓ test 2: no tearing with transition (24 ms)
+      ✓ test 3: ability to interrupt render (1 ms)
+      ✕ test 4: proper branching with transition (7200 ms)
+    with intensive auto increment
+      ✕ test 5: updated properly with auto increment (13208 ms)
+      ✕ test 6: no tearing with auto increment (4 ms)
 ```
+
 </details>
 
 <table>
-<tr><th>Test</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th><th>6</th></tr>	<tr>
-		<th><a href="https://react-redux.js.org">react-redux</a></th>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-	</tr>
-	<tr>
-		<th><a href="https://redux.js.org">redux</a> (w/ useMutableSource)</th>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-	</tr>
-	<tr>
-		<th><a href="https://github.com/dai-shi/reactive-react-redux">reactive-react-redux</a></th>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-	</tr>
-	<tr>
-		<th><a href="https://react-tracked.js.org">react-tracked</a></th>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-	</tr>
-	<tr>
-		<th><a href="https://github.com/diegohaz/constate">constate</a></th>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-	</tr>
-	<tr>
-		<th><a href="https://github.com/pmndrs/zustand">zustand</a></th>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-	</tr>
-	<tr>
-		<th><a href="https://github.com/dai-shi/react-hooks-global-state">react-hooks-global-state</a></th>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-	</tr>
-	<tr>
-		<th><a href="https://github.com/dai-shi/use-context-selector">use-context-selector</a> (w/ useReducer)</th>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-	</tr>
-	<tr>
-		<th><a href="https://github.com/facebook/react/tree/master/packages/use-subscription">use-subscription</a> (w/ redux)</th>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-	</tr>
-	<tr>
-		<th>React useContext / useCallback</th>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-	</tr>
-	<tr>
-		<th><a href="https://github.com/MrWolfZ/simplux">simplux</a></th>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-	</tr>
-	<tr>
-		<th><a href="https://github.com/apollographql/apollo-client">apollo-client</a></th>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-	</tr>
-	<tr>
-		<th><a href="https://recoiljs.org">recoil</a></th>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-	</tr>
-	<tr>
-		<th><a href="https://github.com/pmndrs/jotai">jotai</a></th>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-	</tr>
-	<tr>
-		<th><a href="https://github.com/zerobias/effector">effector</a></th>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-	</tr>
-	<tr>
-		<th><a href="https://react-rxjs.org">react-rxjs</a></th>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-	</tr>
-	<tr>
-		<th><a href="https://github.com/pmndrs/valtio">valtio</a></th>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-	</tr>
-	<tr>
-		<th><a href="https://github.com/selsamman/proxily">proxily</a></th>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:white_check_mark:</td>
-		<td>:x:</td>
-		<td>:x:</td>
-		<td>:white_check_mark:</td>
-	</tr>
+  <tr>
+    <th>Test</th>
+    <th>1</th>
+    <th>2</th>
+    <th>3</th>
+    <th>4</th>
+    <th>5</th>
+    <th>6</th>
+  </tr>
+
+  <tr>
+    <th><a href="https://react-redux.js.org">react-redux</a></th>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://redux.js.org">redux</a> (w/ useMutableSource)</th>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/dai-shi/reactive-react-redux">reactive-react-redux</a></th>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://react-tracked.js.org">react-tracked</a></th>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/diegohaz/constate">constate</a></th>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/pmndrs/zustand">zustand</a></th>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/dai-shi/react-hooks-global-state">react-hooks-global-state</a></th>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:x:</td>
+    <td>:x:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/dai-shi/use-context-selector">use-context-selector</a> (w/ useReducer)</th>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/facebook/react/tree/master/packages/use-subscription">use-subscription</a> (w/ redux)</th>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:x:</td>
+    <td>:x:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/MrWolfZ/simplux">simplux</a></th>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/apollographql/apollo-client">apollo-client</a></th>
+    <td>:x:</td>
+    <td>:x:</td>
+    <td>:x:</td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://recoiljs.org">recoil</a></th>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/pmndrs/jotai">jotai</a></th>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:x:</td>
+    <td>:x:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/zerobias/effector">effector</a></th>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://react-rxjs.org">react-rxjs</a></th>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/pmndrs/valtio">valtio</a></th>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+    <td>:x:</td>
+    <td>:x:</td>
+    <td>:x:</td>
+  </tr>
 
 </table>
 
@@ -434,9 +432,3 @@ https://github.com/dai-shi/lets-compare-global-state-with-react-hooks
 in which we accept contributions. It's recommended to run this tool
 and we put the result there, possibly a reference link to a PR
 in this repository or a fork of this repository.
-
-To automatically run tests and update the README.md on OSX:
-```
-yarn jest:json
-yarn jest:update
-```

--- a/README.md
+++ b/README.md
@@ -72,333 +72,335 @@ yarn run jest
 <summary>Raw Output</summary>
 
 ```
-  react-redux
-    with useTransition
-      ✓ test 1: updated properly with transition (2711 ms)
-      ✕ test 2: no tearing with transition (56 ms)
-      ✓ test 3: ability to interrupt render
-      ✕ test 4: proper branching with transition (7201 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (2230 ms)
-      ✕ test 6: no tearing with auto increment (1 ms)
-  redux-use-mutable-source
-    with useTransition
-      ✓ test 1: updated properly with transition (2745 ms)
-      ✓ test 2: no tearing with transition (122 ms)
-      ✓ test 3: ability to interrupt render
-      ✕ test 4: proper branching with transition (7512 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (2229 ms)
-      ✕ test 6: no tearing with auto increment (1 ms)
-  reactive-react-redux
-    with useTransition
-      ✓ test 1: updated properly with transition (2738 ms)
-      ✓ test 2: no tearing with transition (121 ms)
-      ✓ test 3: ability to interrupt render
-      ✕ test 4: proper branching with transition (7536 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (2205 ms)
-      ✕ test 6: no tearing with auto increment (1 ms)
-  react-tracked
-    with useTransition
-      ✓ test 1: updated properly with transition (3632 ms)
-      ✓ test 2: no tearing with transition (29 ms)
-      ✓ test 3: ability to interrupt render
-      ✓ test 4: proper branching with transition (5411 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (6182 ms)
-      ✓ test 6: no tearing with auto increment (1 ms)
-  constate
-    with useTransition
-      ✓ test 1: updated properly with transition (2863 ms)
-      ✓ test 2: no tearing with transition (46 ms)
-      ✓ test 3: ability to interrupt render
-      ✓ test 4: proper branching with transition (3396 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (4006 ms)
-      ✓ test 6: no tearing with auto increment (1 ms)
-  zustand
-    with useTransition
-      ✓ test 1: updated properly with transition (2653 ms)
-      ✕ test 2: no tearing with transition (46 ms)
-      ✓ test 3: ability to interrupt render
-      ✕ test 4: proper branching with transition (7211 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (2208 ms)
-      ✕ test 6: no tearing with auto increment (1 ms)
-  react-hooks-global-state
-    with useTransition
-      ✓ test 1: updated properly with transition (3496 ms)
-      ✓ test 2: no tearing with transition (25 ms)
-      ✓ test 3: ability to interrupt render
-      ✕ test 4: proper branching with transition (7211 ms)
-    with intensive auto increment
-      ✕ test 5: updated properly with auto increment (13189 ms)
-      ✕ test 6: no tearing with auto increment (4 ms)
-  use-context-selector
-    with useTransition
-      ✓ test 1: updated properly with transition (3626 ms)
-      ✓ test 2: no tearing with transition (31 ms)
-      ✓ test 3: ability to interrupt render
-      ✓ test 4: proper branching with transition (5422 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (6149 ms)
-      ✓ test 6: no tearing with auto increment (1 ms)
-  use-subscription
-    with useTransition
-      ✓ test 1: updated properly with transition (3531 ms)
-      ✓ test 2: no tearing with transition (122 ms)
-      ✓ test 3: ability to interrupt render
-      ✕ test 4: proper branching with transition (7531 ms)
-    with intensive auto increment
-      ✕ test 5: updated properly with auto increment (13207 ms)
-      ✕ test 6: no tearing with auto increment (6 ms)
-  react-state
-    with useTransition
-      ✓ test 1: updated properly with transition (2828 ms)
-      ✓ test 2: no tearing with transition (43 ms)
-      ✓ test 3: ability to interrupt render
-      ✓ test 4: proper branching with transition (3408 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (4014 ms)
-      ✓ test 6: no tearing with auto increment (1 ms)
-  simplux
-    with useTransition
-      ✓ test 1: updated properly with transition (2813 ms)
-      ✓ test 2: no tearing with transition (46 ms)
-      ✓ test 3: ability to interrupt render (1 ms)
-      ✕ test 4: proper branching with transition (7364 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (4097 ms)
-      ✓ test 6: no tearing with auto increment (1 ms)
-  apollo-client
-    with useTransition
-      ✕ test 1: updated properly with transition (4837 ms)
-      ✕ test 2: no tearing with transition (51 ms)
-      ✕ test 3: ability to interrupt render (1 ms)
-      ✕ test 4: proper branching with transition (3675 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (2279 ms)
-      ✕ test 6: no tearing with auto increment (1 ms)
-  recoil
-    with useTransition
-      ✕ test 1: updated properly with transition (5603 ms)
-      ✓ test 2: no tearing with transition (53 ms)
-      ✕ test 3: ability to interrupt render (1 ms)
-      ✕ test 4: proper branching with transition (4367 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (3062 ms)
-      ✓ test 6: no tearing with auto increment (1 ms)
-  jotai
-    with useTransition
-      ✓ test 1: updated properly with transition (3562 ms)
-      ✓ test 2: no tearing with transition (122 ms)
-      ✓ test 3: ability to interrupt render
-      ✕ test 4: proper branching with transition (7543 ms)
-    with intensive auto increment
-      ✕ test 5: updated properly with auto increment (13214 ms)
-      ✕ test 6: no tearing with auto increment (4 ms)
-  effector
-    with useTransition
-      ✓ test 1: updated properly with transition (2677 ms)
-      ✕ test 2: no tearing with transition (48 ms)
-      ✓ test 3: ability to interrupt render
-      ✕ test 4: proper branching with transition (7184 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (2218 ms)
-      ✕ test 6: no tearing with auto increment (1 ms)
-  react-rxjs
-    with useTransition
-      ✕ test 1: updated properly with transition (5886 ms)
-      ✓ test 2: no tearing with transition (58 ms)
-      ✕ test 3: ability to interrupt render
-      ✕ test 4: proper branching with transition (4521 ms)
-    with intensive auto increment
-      ✓ test 5: updated properly with auto increment (3014 ms)
-      ✓ test 6: no tearing with auto increment (2 ms)
-  valtio
-    with useTransition
-      ✓ test 1: updated properly with transition (3453 ms)
-      ✓ test 2: no tearing with transition (24 ms)
-      ✓ test 3: ability to interrupt render (1 ms)
-      ✕ test 4: proper branching with transition (7200 ms)
-    with intensive auto increment
-      ✕ test 5: updated properly with auto increment (13208 ms)
-      ✕ test 6: no tearing with auto increment (4 ms)
-```
+ react-redux
+   with useTransition
+     ✕ test 1: updated properly with transition (1620 ms)
+     ✕ test 2: no tearing with transition (844 ms)
+     ✓ test 3: ability to interrupt render (1 ms)
+     ✕ test 4: proper branching with transition (7181 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (2205 ms)
+     ✕ test 6: no tearing with auto increment (2 ms)
+ redux-use-mutable-source
+   with useTransition
+     ✓ test 1: updated properly with transition (2739 ms)
+     ✓ test 2: no tearing with transition (129 ms)
+     ✓ test 3: ability to interrupt render
+     ✕ test 4: proper branching with transition (7520 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (2200 ms)
+     ✕ test 6: no tearing with auto increment (2 ms)
+ reactive-react-redux
+   with useTransition
+     ✓ test 1: updated properly with transition (2708 ms)
+     ✓ test 2: no tearing with transition (131 ms)
+     ✓ test 3: ability to interrupt render
+     ✕ test 4: proper branching with transition (7497 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (2204 ms)
+     ✕ test 6: no tearing with auto increment (2 ms)
+ react-tracked
+   with useTransition
+     ✓ test 1: updated properly with transition (3573 ms)
+     ✓ test 2: no tearing with transition (94 ms)
+     ✓ test 3: ability to interrupt render
+     ✓ test 4: proper branching with transition (5454 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (6110 ms)
+     ✓ test 6: no tearing with auto increment (1 ms)
+ constate
+   with useTransition
+     ✓ test 1: updated properly with transition (2812 ms)
+     ✓ test 2: no tearing with transition (39 ms)
+     ✓ test 3: ability to interrupt render (1 ms)
+     ✓ test 4: proper branching with transition (3469 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (3987 ms)
+     ✓ test 6: no tearing with auto increment (1 ms)
+ zustand
+   with useTransition
+     ✕ test 1: updated properly with transition (1584 ms)
+     ✕ test 2: no tearing with transition (861 ms)
+     ✓ test 3: ability to interrupt render
+     ✕ test 4: proper branching with transition (7168 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (2196 ms)
+     ✕ test 6: no tearing with auto increment (1 ms)
+ react-hooks-global-state
+   with useTransition
+     ✓ test 1: updated properly with transition (3330 ms)
+     ✓ test 2: no tearing with transition (43 ms)
+     ✓ test 3: ability to interrupt render
+     ✕ test 4: proper branching with transition (7187 ms)
+   with intensive auto increment
+     ✕ test 5: updated properly with auto increment (13182 ms)
+     ✕ test 6: no tearing with auto increment (1 ms)
+ use-context-selector
+   with useTransition
+     ✓ test 1: updated properly with transition (3584 ms)
+     ✓ test 2: no tearing with transition (50 ms)
+     ✓ test 3: ability to interrupt render (1 ms)
+     ✓ test 4: proper branching with transition (5350 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (6137 ms)
+     ✓ test 6: no tearing with auto increment (2 ms)
+ use-subscription
+   with useTransition
+     ✓ test 1: updated properly with transition (3465 ms)
+     ✓ test 2: no tearing with transition (134 ms)
+     ✓ test 3: ability to interrupt render
+     ✕ test 4: proper branching with transition (7514 ms)
+   with intensive auto increment
+     ✕ test 5: updated properly with auto increment (13175 ms)
+     ✕ test 6: no tearing with auto increment (2 ms)
+ react-state
+   with useTransition
+     ✓ test 1: updated properly with transition (2759 ms)
+     ✓ test 2: no tearing with transition (36 ms)
+     ✓ test 3: ability to interrupt render
+     ✓ test 4: proper branching with transition (3442 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (4007 ms)
+     ✓ test 6: no tearing with auto increment (2 ms)
+ simplux
+   with useTransition
+     ✓ test 1: updated properly with transition (2809 ms)
+     ✓ test 2: no tearing with transition (39 ms)
+     ✓ test 3: ability to interrupt render (1 ms)
+     ✕ test 4: proper branching with transition (7347 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (4067 ms)
+     ✓ test 6: no tearing with auto increment (1 ms)
+ apollo-client
+   with useTransition
+     ✕ test 1: updated properly with transition (4577 ms)
+     ✕ test 2: no tearing with transition (39 ms)
+     ✕ test 3: ability to interrupt render (1 ms)
+     ✕ test 4: proper branching with transition (3550 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (2242 ms)
+     ✕ test 6: no tearing with auto increment (1 ms)
+ recoil
+   with useTransition
+     ✕ test 1: updated properly with transition (5774 ms)
+     ✓ test 2: no tearing with transition (40 ms)
+     ✕ test 3: ability to interrupt render
+     ✕ test 4: proper branching with transition (4473 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (3003 ms)
+     ✓ test 6: no tearing with auto increment (1 ms)
+ jotai
+   with useTransition
+     ✓ test 1: updated properly with transition (3489 ms)
+     ✓ test 2: no tearing with transition (132 ms)
+     ✓ test 3: ability to interrupt render
+     ✕ test 4: proper branching with transition (7523 ms)
+   with intensive auto increment
+     ✕ test 5: updated properly with auto increment (13180 ms)
+     ✕ test 6: no tearing with auto increment (1 ms)
+ effector
+   with useTransition
+     ✕ test 1: updated properly with transition (1600 ms)
+     ✕ test 2: no tearing with transition (873 ms)
+     ✓ test 3: ability to interrupt render
+     ✕ test 4: proper branching with transition (7135 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (2198 ms)
+     ✕ test 6: no tearing with auto increment (1 ms)
+ react-rxjs
+   with useTransition
+     ✕ test 1: updated properly with transition (5749 ms)
+     ✓ test 2: no tearing with transition (37 ms)
+     ✕ test 3: ability to interrupt render (1 ms)
+     ✕ test 4: proper branching with transition (4488 ms)
+   with intensive auto increment
+     ✓ test 5: updated properly with auto increment (2999 ms)
+     ✓ test 6: no tearing with auto increment (1 ms)
+ valtio
+   with useTransition
+     ✓ test 1: updated properly with transition (3374 ms)
+     ✓ test 2: no tearing with transition (39 ms)
+     ✓ test 3: ability to interrupt render
+     ✕ test 4: proper branching with transition (7179 ms)
+   with intensive auto increment
+     ✕ test 5: updated properly with auto increment (13172 ms)
+     ✕ test 6: no tearing with auto increment (1 ms)
+ proxily
+   with useTransition
+     ✓ test 1: updated properly with transition (2809 ms)
+     ✓ test 2: no tearing with transition (42 ms)
+     ✓ test 3: ability to interrupt render (1 ms)
+     ✕ test 4: proper branching with transition (7372 ms)
+   with intensive auto increment
+     ✕ test 5: updated properly with auto increment (12180 ms)
+     ✓ test 6: no tearing with auto increment (2 ms)
 
+```
 </details>
 
 <table>
-  <tr>
-    <th>Test</th>
-    <th>1</th>
-    <th>2</th>
-    <th>3</th>
-    <th>4</th>
-    <th>5</th>
-    <th>6</th>
-  </tr>
-
-  <tr>
-    <th><a href="https://react-redux.js.org">react-redux</a></th>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://redux.js.org">redux</a> (w/ useMutableSource)</th>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://github.com/dai-shi/reactive-react-redux">reactive-react-redux</a></th>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://react-tracked.js.org">react-tracked</a></th>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://github.com/diegohaz/constate">constate</a></th>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://github.com/pmndrs/zustand">zustand</a></th>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://github.com/dai-shi/react-hooks-global-state">react-hooks-global-state</a></th>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:x:</td>
-    <td>:x:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://github.com/dai-shi/use-context-selector">use-context-selector</a> (w/ useReducer)</th>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://github.com/facebook/react/tree/master/packages/use-subscription">use-subscription</a> (w/ redux)</th>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:x:</td>
-    <td>:x:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://github.com/MrWolfZ/simplux">simplux</a></th>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://github.com/apollographql/apollo-client">apollo-client</a></th>
-    <td>:x:</td>
-    <td>:x:</td>
-    <td>:x:</td>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://recoiljs.org">recoil</a></th>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://github.com/pmndrs/jotai">jotai</a></th>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:x:</td>
-    <td>:x:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://github.com/zerobias/effector">effector</a></th>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://react-rxjs.org">react-rxjs</a></th>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:x:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-  </tr>
-
-  <tr>
-    <th><a href="https://github.com/pmndrs/valtio">valtio</a></th>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-    <td>:x:</td>
-    <td>:x:</td>
-  </tr>
+<tr><th>Test</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th><th>6</th></tr>	<tr>
+		<th><a href="https://react-redux.js.org">react-redux</a></th>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+	</tr>
+	<tr>
+		<th><a href="https://redux.js.org">redux</a> (w/ useMutableSource)</th>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+	</tr>
+	<tr>
+		<th><a href="https://github.com/dai-shi/reactive-react-redux">reactive-react-redux</a></th>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+	</tr>
+	<tr>
+		<th><a href="https://react-tracked.js.org">react-tracked</a></th>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+	</tr>
+	<tr>
+		<th><a href="https://github.com/diegohaz/constate">constate</a></th>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+	</tr>
+	<tr>
+		<th><a href="https://github.com/pmndrs/zustand">zustand</a></th>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+	</tr>
+	<tr>
+		<th><a href="https://github.com/dai-shi/react-hooks-global-state">react-hooks-global-state</a></th>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+	</tr>
+	<tr>
+		<th><a href="https://github.com/dai-shi/use-context-selector">use-context-selector</a> (w/ useReducer)</th>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+	</tr>
+	<tr>
+		<th><a href="https://github.com/facebook/react/tree/master/packages/use-subscription">use-subscription</a> (w/ redux)</th>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+	</tr>
+	<tr>
+		<th>React useContext / useCallback</th>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+	</tr>
+	<tr>
+		<th><a href="https://github.com/MrWolfZ/simplux">simplux</a></th>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+	</tr>
+	<tr>
+		<th><a href="https://github.com/apollographql/apollo-client">apollo-client</a></th>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+	</tr>
+	<tr>
+		<th><a href="https://recoiljs.org">recoil</a></th>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+	</tr>
+	<tr>
+		<th><a href="https://github.com/pmndrs/jotai">jotai</a></th>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+	</tr>
+	<tr>
+		<th><a href="https://github.com/zerobias/effector">effector</a></th>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+	</tr>
+	<tr>
+		<th><a href="https://react-rxjs.org">react-rxjs</a></th>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+	</tr>
+	<tr>
+		<th><a href="https://github.com/pmndrs/valtio">valtio</a></th>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+	</tr>
+	<tr>
+		<th><a href="https://github.com/selsamman/proxily">proxily</a></th>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:white_check_mark:</td>
+		<td>:x:</td>
+		<td>:x:</td>
+		<td>:white_check_mark:</td>
+	</tr>
 
 </table>
 
@@ -432,3 +434,9 @@ https://github.com/dai-shi/lets-compare-global-state-with-react-hooks
 in which we accept contributions. It's recommended to run this tool
 and we put the result there, possibly a reference link to a PR
 in this repository or a fork of this repository.
+
+To automatically run tests and update the README.md on OSX:
+```
+yarn jest:json
+yarn jest:update
+```

--- a/__tests__/all_spec.js
+++ b/__tests__/all_spec.js
@@ -144,12 +144,17 @@ names.forEach((name) => {
           text: 'Pending...',
           timeout: 2 * 1000,
         });
+        // Make sure that while isPending true, previous state displayed
+        await expect(page.evaluate(() => document.querySelector('#maincount').innerHTML)).resolves.toBe('0');
+        await expect(page.evaluate(() => document.querySelector('.count:first-of-type').innerHTML)).resolves.toBe('0');
         await sleep(1000); // this is a magic number (better way?)
         // wait until pending disappers
         await expect(page).toMatchElement('#pending', {
           text: '',
           timeout: 10 * 1000,
         });
+        // Main state should be changed
+        await expect(page.evaluate(() => document.querySelector('#maincount').innerHTML)).resolves.not.toBe('0');
         // the first one should be changed
         await expect(page.evaluate(() => document.querySelector('.count:first-of-type').innerHTML)).resolves.not.toBe('0');
       });

--- a/__tests__/all_spec.js
+++ b/__tests__/all_spec.js
@@ -145,7 +145,7 @@ names.forEach((name) => {
           timeout: 2 * 1000,
         });
         // Make sure that while isPending true, previous state displayed
-        await expect(page.evaluate(() => document.querySelector('#maincount').innerHTML)).resolves.toBe('0');
+        await expect(page.evaluate(() => document.querySelector('#mainCount').innerHTML)).resolves.toBe('0');
         await expect(page.evaluate(() => document.querySelector('.count:first-of-type').innerHTML)).resolves.toBe('0');
         await sleep(1000); // this is a magic number (better way?)
         // wait until pending disappers
@@ -154,7 +154,7 @@ names.forEach((name) => {
           timeout: 10 * 1000,
         });
         // Main state should be changed
-        await expect(page.evaluate(() => document.querySelector('#maincount').innerHTML)).resolves.not.toBe('0');
+        await expect(page.evaluate(() => document.querySelector('#mainCount').innerHTML)).resolves.not.toBe('0');
         // the first one should be changed
         await expect(page.evaluate(() => document.querySelector('.count:first-of-type').innerHTML)).resolves.not.toBe('0');
       });

--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <title>dev</title>
     <style>


### PR DESCRIPTION
Updated test 1 to ensure that pre-transition values remain rendering during the part of the transition where isPending is true.  This is done by examining the count returned from useCount to see it remains zero during isPending and become non-zero when the transition completes (isPending false).  3 libraries fail test 1 as a result so README.md is updated as well. Mentioned in #47 